### PR TITLE
lpc_periph.v: change module ports' comments to format understood by S…

### DIFF
--- a/.github/workflows/lint-verilog.yml
+++ b/.github/workflows/lint-verilog.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: reviewdog/action-setup@v1
-    - uses: 3mdeb/verilog-cleaner@v2
+    - uses: 3mdeb/verilog-cleaner@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         reporter: github-pr-review

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ It can be also easily simulated in open-source Verilog simulator - [Icarus
 Verilog](http://iverilog.icarus.com/) and visualized in the
 [GTKWave](http://gtkwave.sourceforge.net/).
 
+## Module diagram
+
+![Module diagram](lpc_periph.svg)
+
+Inputs are on the left side, outputs and bi-directional wires on the right.
+
 ## Simulation
 
 ### Prerequisites

--- a/lpc_periph.svg
+++ b/lpc_periph.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="507" height="217" viewBox="-99 -20 507.0 217.0" version="1.1">
+width="507" height="225" viewBox="-99 -20 507.0 225.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,91 +19,96 @@ width="507" height="217" viewBox="-99 -20 507.0 217.0" version="1.1">
 ]]>
 </style>
 <defs>
-<marker id="arrow_fwd" markerWidth="8.0" markerHeight="8.0" viewBox="0 0 8.0 8.0" refX="3.2" refY="4.0" orient="auto" markerUnits="userSpaceOnUse">
-<g transform="translate(-0.0,4.0)"><path d="M 0 -4 C 2 -1, 2 1, 0 4 L 8 0 z" stroke="none" fill="#000000"/>
+<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
 </g>
 </marker>
 <marker id="arrow_back" markerWidth="8.0" markerHeight="8.0" viewBox="0 0 8.0 8.0" refX="4.8" refY="4.0" orient="auto" markerUnits="userSpaceOnUse">
 <g transform="translate(8.0,4.0)"><path d="M 0 -4 C -2 -1, -2 1, 0 4 L -8 0 z" stroke="none" fill="#000000"/>
 </g>
 </marker>
-<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
-<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+<marker id="arrow_fwd" markerWidth="8.0" markerHeight="8.0" viewBox="0 0 8.0 8.0" refX="3.2" refY="4.0" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(-0.0,4.0)"><path d="M 0 -4 C 2 -1, 2 1, 0 4 L 8 0 z" stroke="none" fill="#000000"/>
 </g>
 </marker>
 </defs>
 <rect x="-99" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="300" height="93.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<text class="fnt1" x="150.0" y="0" text-anchor="middle" dy="6.5">LPC interface</text>
-<g transform="translate(0,23)">
+<rect x="0" y="-15.0" width="300" height="87.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<text class="fnt1" x="150.0" y="0" text-anchor="middle" dy="2.5">LPC interface</text>
+<g transform="translate(0,17)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="7.0">clk_i</text>
-<text class="fnt2" x="-30" y="0" text-anchor="end" dy="7.0" style="fill:#969696">wire</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="3.5">clk_i</text>
+<text class="fnt2" x="-30" y="0" text-anchor="end" dy="3.5" style="fill:#969696">wire</text>
 </g>
-<g transform="translate(0,43)">
+<g transform="translate(0,37)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="7.0">nrst_i</text>
-<text class="fnt2" x="-30" y="0" text-anchor="end" dy="7.0" style="fill:#969696">wire</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="3.5">nrst_i</text>
+<text class="fnt2" x="-30" y="0" text-anchor="end" dy="3.5" style="fill:#969696">wire</text>
 </g>
-<g transform="translate(0,63)">
+<g transform="translate(0,57)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="7.0">lframe_i</text>
-<text class="fnt2" x="-30" y="0" text-anchor="end" dy="7.0" style="fill:#969696">wire</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="3.5">lframe_i</text>
+<text class="fnt2" x="-30" y="0" text-anchor="end" dy="3.5" style="fill:#969696">wire</text>
 </g>
-<g transform="translate(300,23)">
+<g transform="translate(300,17)">
 <line x1="16.16" y1="4.702643708725836e-16" x2="3.84" y2="-4.702643708725836e-16" stroke="#000000" fill="none" stroke-width="3" marker-start="url(#arrow_back)" marker-end="url(#arrow_fwd)"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="7.0">lad_bus</text>
-<text class="fnt2" x="30" y="0" text-anchor="normal" dy="7.0" style="fill:#969696">wire <tspan fill="#039BE5">[3:0]</tspan></text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="3.5">lad_bus</text>
+<text class="fnt2" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">wire <tspan fill="#039BE5">[3:0]</tspan></text>
 </g>
-<g transform="translate(300,43)">
+<g transform="translate(300,37)">
 <line x1="16.16" y1="4.702643708725836e-16" x2="3.84" y2="-4.702643708725836e-16" stroke="#000000" fill="none" stroke-width="1" marker-start="url(#arrow_back)" marker-end="url(#arrow_fwd)"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="7.0">serirq</text>
-<text class="fnt2" x="30" y="0" text-anchor="normal" dy="7.0" style="fill:#969696">wire</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="3.5">serirq</text>
+<text class="fnt2" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">wire</text>
 </g>
 </g>
-<g transform="translate(0,93.0)">
-<rect x="0" y="-15.0" width="300" height="113.0" stroke="#000000" fill="#E7FDBA" stroke-width="1"/>
-<text class="fnt1" x="150.0" y="0" text-anchor="middle" dy="6.5">Interface to data provider</text>
-<g transform="translate(0,23)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="7.0">lpc_wr_done</text>
-<text class="fnt2" x="-30" y="0" text-anchor="end" dy="7.0" style="fill:#969696">wire</text>
-</g>
-<g transform="translate(0,43)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="7.0">lpc_data_rd</text>
-<text class="fnt2" x="-30" y="0" text-anchor="end" dy="7.0" style="fill:#969696">wire</text>
-</g>
-<g transform="translate(0,63)">
+<g transform="translate(0,87.0)">
+<rect x="0" y="-15.0" width="300" height="127.0" stroke="#000000" fill="#E7FDBA" stroke-width="1"/>
+<text class="fnt1" x="150.0" y="0" text-anchor="middle" dy="2.5">Interface to data provider</text>
+<g transform="translate(0,17)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="7.0">irq_num</text>
-<text class="fnt2" x="-30" y="0" text-anchor="end" dy="7.0" style="fill:#969696">wire <tspan fill="#039BE5">[3:0]</tspan></text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="3.5">lpc_data_i</text>
+<text class="fnt2" x="-30" y="0" text-anchor="end" dy="3.5" style="fill:#969696">wire <tspan fill="#039BE5">[7:0]</tspan></text>
 </g>
-<g transform="translate(0,83)">
+<g transform="translate(0,37)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="7.0">interrupt</text>
-<text class="fnt2" x="-30" y="0" text-anchor="end" dy="7.0" style="fill:#969696">wire</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="3.5">lpc_wr_done</text>
+<text class="fnt2" x="-30" y="0" text-anchor="end" dy="3.5" style="fill:#969696">wire</text>
 </g>
-<g transform="translate(300,23)">
-<line x1="16.16" y1="4.702643708725836e-16" x2="3.84" y2="-4.702643708725836e-16" stroke="#000000" fill="none" stroke-width="3" marker-start="url(#arrow_back)" marker-end="url(#arrow_fwd)"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="7.0">lpc_data_io</text>
-<text class="fnt2" x="30" y="0" text-anchor="normal" dy="7.0" style="fill:#969696">wire <tspan fill="#039BE5">[7:0]</tspan></text>
+<g transform="translate(0,57)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="3.5">lpc_data_rd</text>
+<text class="fnt2" x="-30" y="0" text-anchor="end" dy="3.5" style="fill:#969696">wire</text>
 </g>
-<g transform="translate(300,43)">
+<g transform="translate(0,77)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="3.5">irq_num</text>
+<text class="fnt2" x="-30" y="0" text-anchor="end" dy="3.5" style="fill:#969696">wire <tspan fill="#039BE5">[3:0]</tspan></text>
+</g>
+<g transform="translate(0,97)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="3.5">interrupt</text>
+<text class="fnt2" x="-30" y="0" text-anchor="end" dy="3.5" style="fill:#969696">wire</text>
+</g>
+<g transform="translate(300,17)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="7.0">lpc_addr_o</text>
-<text class="fnt2" x="30" y="0" text-anchor="normal" dy="7.0" style="fill:#969696">wire <tspan fill="#039BE5">[15:0]</tspan></text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="3.5">lpc_data_o</text>
+<text class="fnt2" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">reg <tspan fill="#039BE5">[7:0]</tspan></text>
 </g>
-<g transform="translate(300,63)">
+<g transform="translate(300,37)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="3.5">lpc_addr_o</text>
+<text class="fnt2" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">wire <tspan fill="#039BE5">[15:0]</tspan></text>
+</g>
+<g transform="translate(300,57)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="7.0">lpc_data_wr</text>
-<text class="fnt2" x="30" y="0" text-anchor="normal" dy="7.0" style="fill:#969696">wire</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="3.5">lpc_data_wr</text>
+<text class="fnt2" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">wire</text>
 </g>
-<g transform="translate(300,83)">
+<g transform="translate(300,77)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="7.0">lpc_data_req</text>
-<text class="fnt2" x="30" y="0" text-anchor="normal" dy="7.0" style="fill:#969696">wire</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="3.5">lpc_data_req</text>
+<text class="fnt2" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">wire</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="298.0" height="204.0" stroke="#000000" fill="none" stroke-width="3"/>
+<rect x="1.0" y="-14.0" width="298.0" height="212.0" stroke="#000000" fill="none" stroke-width="3"/>
 </svg>

--- a/lpc_periph.svg
+++ b/lpc_periph.svg
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="507" height="217" viewBox="-99 -20 507.0 217.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+<marker id="arrow_fwd" markerWidth="8.0" markerHeight="8.0" viewBox="0 0 8.0 8.0" refX="3.2" refY="4.0" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(-0.0,4.0)"><path d="M 0 -4 C 2 -1, 2 1, 0 4 L 8 0 z" stroke="none" fill="#000000"/>
+</g>
+</marker>
+<marker id="arrow_back" markerWidth="8.0" markerHeight="8.0" viewBox="0 0 8.0 8.0" refX="4.8" refY="4.0" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(8.0,4.0)"><path d="M 0 -4 C -2 -1, -2 1, 0 4 L -8 0 z" stroke="none" fill="#000000"/>
+</g>
+</marker>
+<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+</defs>
+<rect x="-99" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="300" height="93.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<text class="fnt1" x="150.0" y="0" text-anchor="middle" dy="6.5">LPC interface</text>
+<g transform="translate(0,23)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="7.0">clk_i</text>
+<text class="fnt2" x="-30" y="0" text-anchor="end" dy="7.0" style="fill:#969696">wire</text>
+</g>
+<g transform="translate(0,43)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="7.0">nrst_i</text>
+<text class="fnt2" x="-30" y="0" text-anchor="end" dy="7.0" style="fill:#969696">wire</text>
+</g>
+<g transform="translate(0,63)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="7.0">lframe_i</text>
+<text class="fnt2" x="-30" y="0" text-anchor="end" dy="7.0" style="fill:#969696">wire</text>
+</g>
+<g transform="translate(300,23)">
+<line x1="16.16" y1="4.702643708725836e-16" x2="3.84" y2="-4.702643708725836e-16" stroke="#000000" fill="none" stroke-width="3" marker-start="url(#arrow_back)" marker-end="url(#arrow_fwd)"/>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="7.0">lad_bus</text>
+<text class="fnt2" x="30" y="0" text-anchor="normal" dy="7.0" style="fill:#969696">wire <tspan fill="#039BE5">[3:0]</tspan></text>
+</g>
+<g transform="translate(300,43)">
+<line x1="16.16" y1="4.702643708725836e-16" x2="3.84" y2="-4.702643708725836e-16" stroke="#000000" fill="none" stroke-width="1" marker-start="url(#arrow_back)" marker-end="url(#arrow_fwd)"/>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="7.0">serirq</text>
+<text class="fnt2" x="30" y="0" text-anchor="normal" dy="7.0" style="fill:#969696">wire</text>
+</g>
+</g>
+<g transform="translate(0,93.0)">
+<rect x="0" y="-15.0" width="300" height="113.0" stroke="#000000" fill="#E7FDBA" stroke-width="1"/>
+<text class="fnt1" x="150.0" y="0" text-anchor="middle" dy="6.5">Interface to data provider</text>
+<g transform="translate(0,23)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="7.0">lpc_wr_done</text>
+<text class="fnt2" x="-30" y="0" text-anchor="end" dy="7.0" style="fill:#969696">wire</text>
+</g>
+<g transform="translate(0,43)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="7.0">lpc_data_rd</text>
+<text class="fnt2" x="-30" y="0" text-anchor="end" dy="7.0" style="fill:#969696">wire</text>
+</g>
+<g transform="translate(0,63)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="7.0">irq_num</text>
+<text class="fnt2" x="-30" y="0" text-anchor="end" dy="7.0" style="fill:#969696">wire <tspan fill="#039BE5">[3:0]</tspan></text>
+</g>
+<g transform="translate(0,83)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="7.0">interrupt</text>
+<text class="fnt2" x="-30" y="0" text-anchor="end" dy="7.0" style="fill:#969696">wire</text>
+</g>
+<g transform="translate(300,23)">
+<line x1="16.16" y1="4.702643708725836e-16" x2="3.84" y2="-4.702643708725836e-16" stroke="#000000" fill="none" stroke-width="3" marker-start="url(#arrow_back)" marker-end="url(#arrow_fwd)"/>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="7.0">lpc_data_io</text>
+<text class="fnt2" x="30" y="0" text-anchor="normal" dy="7.0" style="fill:#969696">wire <tspan fill="#039BE5">[7:0]</tspan></text>
+</g>
+<g transform="translate(300,43)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="7.0">lpc_addr_o</text>
+<text class="fnt2" x="30" y="0" text-anchor="normal" dy="7.0" style="fill:#969696">wire <tspan fill="#039BE5">[15:0]</tspan></text>
+</g>
+<g transform="translate(300,63)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="7.0">lpc_data_wr</text>
+<text class="fnt2" x="30" y="0" text-anchor="normal" dy="7.0" style="fill:#969696">wire</text>
+</g>
+<g transform="translate(300,83)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="7.0">lpc_data_req</text>
+<text class="fnt2" x="30" y="0" text-anchor="normal" dy="7.0" style="fill:#969696">wire</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="298.0" height="204.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/lpc_periph.v
+++ b/lpc_periph.v
@@ -34,7 +34,8 @@ module lpc_periph (
     lframe_i,
     lad_bus,
     serirq,
-    lpc_data_io,
+    lpc_data_i,
+    lpc_data_o,
     lpc_addr_o,
     lpc_data_wr,
     lpc_wr_done,
@@ -52,25 +53,25 @@ module lpc_periph (
   inout  wire        serirq;       // LPC SERIRQ signal
 
   //# {{Interface to data provider}}
-  inout  wire [ 7:0] lpc_data_io;  // Data received (I/O Write) or to be sent (I/O Read) to host
+  input  wire [ 7:0] lpc_data_i;   // Data to be sent (I/O Read) to host
+  output reg  [ 7:0] lpc_data_o;   // Data received (I/O Write) from host
   output wire [15:0] lpc_addr_o;   // 16-bit LPC Peripheral Address
-  output wire        lpc_data_wr;  // Signal to data provider that lpc_data_io has valid write data
-  input  wire        lpc_wr_done;  // Signal from data provider that lpc_data_io has been read
-  input  wire        lpc_data_rd;  // Signal from data provider that lpc_data_io has data for read
+  output wire        lpc_data_wr;  // Signal to data provider that lpc_data_o has valid write data
+  input  wire        lpc_wr_done;  // Signal from data provider that lpc_data_o has been read
+  input  wire        lpc_data_rd;  // Signal from data provider that lpc_data_i has data for read
   output wire        lpc_data_req; // Signal to data provider that is requested (@posedge) or
-                                   // has been read (@negedge)
+                                   // has been read (@negedge) from lpc_data_i
   input  wire [ 3:0] irq_num;      // IRQ number, copy of TPM_INT_VECTOR_x.sirqVec
   input  wire        interrupt;    // Whether interrupt should be signaled to host, active high
 
   // Internal signals
   reg [ 4:0] prev_state_o;         // Previous peripheral state (FSM)
   reg [ 4:0] fsm_next_state;       // State: next state of FSM
-  reg [ 7:0] lpc_data_reg_w = 0;   // Copy of lpc_data_io's data (LPC -> data provider)
-  reg [ 7:0] lpc_data_reg_r = 0;   // Copy of lpc_data_io's data (data provider -> LPC)
+  reg [ 7:0] lpc_data_reg = 0;     // Copy of lpc_data_i data (data provider -> LPC)
   reg [15:0] lpc_addr_reg = 0;     // Driver of lpc_addr_o
   reg        waiting_on_write = 0; // LPC interface is waiting for data to be acked by data provider
+  reg        waiting_on_write2 = 0;// Same as above, but driven on complementary edge
   reg        waiting_on_read = 0;  // LPC interface is waiting for data sent from data provider
-  reg        driving_data = 0;     // Data on interface to data provider is driven by LPC module
   reg [ 3:0] irq_num_reg = 0;      // IRQ number, latched on SERIRQ start frame
   reg        serirq_count_en = 0;  // Are we between SERIRQ start (exclusive) and stop (inclusive)?
   reg        serirq_reg = 1;       // Value driven on SERIRQ, if enabled
@@ -166,7 +167,6 @@ module lpc_periph (
   always @(negedge nrst_i or negedge clk_i) begin
     if (~nrst_i) begin
       prev_state_o     <= `LPC_ST_IDLE;
-      driving_data     <= 1'b0;
       waiting_on_write <= 1'b0;
       waiting_on_read  <= 1'b0;
     end else begin
@@ -184,7 +184,7 @@ module lpc_periph (
         `LPC_ST_TAR_RD_CLK2: begin
           // Avoid sync wait if it isn't required
           if (lpc_data_rd == 1'b1) begin
-            lpc_data_reg_r  <= lpc_data_io;
+            lpc_data_reg    <= lpc_data_i;
             waiting_on_read <= 1'b0;
           end
           prev_state_o <= fsm_next_state;
@@ -192,7 +192,7 @@ module lpc_periph (
         `LPC_ST_SYNC_RD: begin
           // FIXME: testbench shows x's in LAD exactly at this point, maybe use Gray codes for FSM?
           if (lpc_data_rd == 1'b1) begin
-            lpc_data_reg_r   <= lpc_data_io;
+            lpc_data_reg     <= lpc_data_i;
             waiting_on_read  <= 1'b0;
           end
           if (waiting_on_read == 1'b0) prev_state_o <= fsm_next_state;
@@ -209,7 +209,7 @@ module lpc_periph (
           prev_state_o <= fsm_next_state;
         end
         `LPC_ST_SYNC_WR: begin
-          if (lpc_wr_done == 1'b1 && driving_data == 1'b0) waiting_on_write <= 1'b0;
+          if (lpc_wr_done == 1'b1 && waiting_on_write2 == 1'b0) waiting_on_write <= 1'b0;
           if (waiting_on_write == 1'b0) prev_state_o <= fsm_next_state;
         end
         default: prev_state_o <= fsm_next_state;
@@ -217,9 +217,11 @@ module lpc_periph (
     end
   end
 
-  always @(posedge clk_i) begin
-    if (nrst_i == 1'b0) fsm_next_state <= `LPC_ST_IDLE;
-    else begin
+  always @(negedge nrst_i or posedge clk_i) begin
+    if (~nrst_i) begin
+      fsm_next_state    <= `LPC_ST_IDLE;
+      waiting_on_write2 <= 1'b0;
+    end else begin
       if (lframe_i == 1'b0) fsm_next_state <= `LPC_ST_IDLE;
       case (prev_state_o)
         `LPC_ST_IDLE: begin
@@ -255,8 +257,8 @@ module lpc_periph (
         `LPC_ST_TAR_RD_CLK1:    fsm_next_state <= `LPC_ST_TAR_RD_CLK2;
         `LPC_ST_TAR_RD_CLK2: begin
           if (lframe_i == 0) begin
-            driving_data  <= 1'b0;
-            fsm_next_state  <= `LPC_ST_IDLE;
+            waiting_on_write2 <= 1'b0;
+            fsm_next_state    <= `LPC_ST_IDLE;
           end else
             fsm_next_state <= `LPC_ST_SYNC_RD;
         end
@@ -281,35 +283,35 @@ module lpc_periph (
           fsm_next_state    <= `LPC_ST_ADDR_WR_CLK4;
         end
         `LPC_ST_ADDR_WR_CLK4: begin
-          lpc_data_reg_w[3:0] <= lad_bus;
-          fsm_next_state      <= `LPC_ST_DATA_WR_CLK1;
+          lpc_data_o[3:0]   <= lad_bus;
+          fsm_next_state    <= `LPC_ST_DATA_WR_CLK1;
         end
         `LPC_ST_DATA_WR_CLK1: begin
-          lpc_data_reg_w[7:4] <= lad_bus;
-          driving_data        <= 1'b1;
-          fsm_next_state      <= `LPC_ST_DATA_WR_CLK2;
+          lpc_data_o[7:4]   <= lad_bus;
+          waiting_on_write2 <= 1'b1;
+          fsm_next_state    <= `LPC_ST_DATA_WR_CLK2;
         end
         `LPC_ST_DATA_WR_CLK2:   fsm_next_state <= `LPC_ST_TAR_WR_CLK1;
         `LPC_ST_TAR_WR_CLK1: begin
           // Avoid sync wait if it isn't required
           if (lpc_wr_done == 1'b1) begin
-            driving_data   <= 1'b0;
+            waiting_on_write2 <= 1'b0;
           end
           fsm_next_state <= `LPC_ST_TAR_WR_CLK2;
         end
         `LPC_ST_TAR_WR_CLK2: begin
           if (lframe_i == 0) begin
-            driving_data   <= 1'b0;
-            fsm_next_state <= `LPC_ST_IDLE;
+            waiting_on_write2 <= 1'b0;
+            fsm_next_state    <= `LPC_ST_IDLE;
           end else if (lpc_wr_done == 1'b1) begin
-            driving_data   <= 1'b0;
-            fsm_next_state <= `LPC_ST_SYNC_WR;
+            waiting_on_write2 <= 1'b0;
+            fsm_next_state    <= `LPC_ST_SYNC_WR;
           end else
             fsm_next_state <= `LPC_ST_SYNC_WR;
         end
         `LPC_ST_SYNC_WR: begin
-          driving_data   <= 1'b0;
-          fsm_next_state <= `LPC_ST_FINAL_TAR_CLK1;
+          waiting_on_write2 <= 1'b0;
+          fsm_next_state    <= `LPC_ST_FINAL_TAR_CLK1;
         end
         `LPC_ST_FINAL_TAR_CLK1: fsm_next_state <= `LPC_ST_IDLE;
         default:                fsm_next_state <= `LPC_ST_IDLE;
@@ -328,13 +330,12 @@ module lpc_periph (
   // TAR
   assign lad_bus = (prev_state_o == `LPC_ST_SYNC_WR ||
                     prev_state_o == `LPC_ST_DATA_RD_CLK2) ? 4'b1111 : 4'bzzzz;
-  assign lad_bus = (prev_state_o == `LPC_ST_SYNC_RD) ? lpc_data_reg_r[3:0] : 4'bzzzz;
-  assign lad_bus = (prev_state_o == `LPC_ST_DATA_RD_CLK1) ? lpc_data_reg_r[7:4] : 4'bzzzz;
+  assign lad_bus = (prev_state_o == `LPC_ST_SYNC_RD) ? lpc_data_reg[3:0] : 4'bzzzz;
+  assign lad_bus = (prev_state_o == `LPC_ST_DATA_RD_CLK1) ? lpc_data_reg[7:4] : 4'bzzzz;
 
   assign serirq = driving_serirq ? serirq_reg : 1'bz;
 
   assign lpc_addr_o   = lpc_addr_reg;
-  assign lpc_data_io  = (driving_data == 1'b1 && waiting_on_write == 1'b1) ? lpc_data_reg_w : 8'hzz;
   assign lpc_data_wr  = waiting_on_write;
   assign lpc_data_req = waiting_on_read;
 endmodule

--- a/lpc_periph.v
+++ b/lpc_periph.v
@@ -44,14 +44,14 @@ module lpc_periph (
     interrupt
 );
   // verilog_format: off  // verible-verilog-format messes up comments alignment
-  // LPC interface
+  //# {{LPC interface}}
   input  wire        clk_i;        // LPC clock
   input  wire        nrst_i;       // LPC reset (active low)
   input  wire        lframe_i;     // LPC frame input (active low)
   inout  wire [ 3:0] lad_bus;      // LPC data bus
   inout  wire        serirq;       // LPC SERIRQ signal
 
-  // Interface to data provider
+  //# {{Interface to data provider}}
   inout  wire [ 7:0] lpc_data_io;  // Data received (I/O Write) or to be sent (I/O Read) to host
   output wire [15:0] lpc_addr_o;   // 16-bit LPC Peripheral Address
   output wire        lpc_data_wr;  // Signal to data provider that lpc_data_io has valid write data


### PR DESCRIPTION
…ymbolator

Symbolator [1] is a tool for automatic creation of images describing Verilog modules ports. By using proper format of metacomments signals on the produced diagrams can be divided in sections based on their designation.

1: https://kevinpt.github.io/symbolator/