### PR TITLE
Explicity set serirq_counter size

### DIFF
--- a/lpc_periph.v
+++ b/lpc_periph.v
@@ -82,7 +82,7 @@ module lpc_periph (
   // verilog_format: on
 
   always @(negedge nrst_i or posedge clk_i) begin : serirq_drive
-    integer    serirq_counter;
+    reg [5:0] serirq_counter;
     if (~nrst_i) begin
       serirq_counter <= 0;
       serirq_reg     <= 1;


### PR DESCRIPTION
When using integer keyword for declaring registers, yosys does not automatically detect how many bits we need, instead all registers are given size of 32.